### PR TITLE
COMP: Build on TravisCI with osx_image xcode 10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: true
 language: cpp
 os:
 - osx
+  osx_image: xcode10.1
 compiler:
 - gcc
 cache:


### PR DESCRIPTION
The ITKPythonBuilds were built with a compiler that contain the 10.14
SDK.