### PR TITLE
COMP: Remove unused variable.

### DIFF
--- a/include/itkLabelSetMorphBaseImageFilter.hxx
+++ b/include/itkLabelSetMorphBaseImageFilter.hxx
@@ -176,8 +176,6 @@ LabelSetMorphBaseImageFilter< TInputImage, doDilate, TOutputImage >
     }
   else
     {
-    // radius is in pixels
-    RadiusType R;
     // this gives us a little bit of a margin
     for ( unsigned P = 0; P < InputImageType::ImageDimension; P++ )
       {


### PR DESCRIPTION
Remove unused variable `R`. Fixes:
```
[CTest: warning matched]
/Users/Kitware/Dashboards/TestsModules/Remote/LabelErodeDilate/
include/itkLabelSetMorphBaseImageFilter.hxx:180:16:
warning: unused variable 'R' [-Wunused-variable]
    RadiusType R;
                   ^
```

reported at:
http://testing.cdash.org/viewBuildError.php?type=1&buildid=5793030