### PR TITLE
COMP: Change to enum to new enum class definitions

### DIFF
--- a/test/read_info.cxx
+++ b/test/read_info.cxx
@@ -22,7 +22,7 @@
 /////////////////////////////////
 static int readImageInfo(char *filename, itk::ImageIOBase::IOComponentType *ComponentType, int *dim)
 {
-  itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(filename, itk::ImageIOFactory::ReadMode);
+  itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(filename, itk::ImageIOFactory::FileModeType::ReadMode);
 
   if ( imageIO.IsNull() )
     {


### PR DESCRIPTION
When ITK is configured with the following:

- ITK_LEGACY_REMOVE = ON

- ITK_FUTURE_LEGACY_REMOVE = ON

- ITK_LEGACY_SILENT = OFF

- Module_LabelErodeDilate = ON

Build errors occur with references to older 'C' style enums. The following changes incorporate the new enum class: FileModeType and resolves such errors.

Co-Authored-By: Hans Johnson hans-johnson@uiowa.edu