### PR TITLE
BUG: Fix failing filter and KW-Style tests

### DIFF
--- a/include/itkLabelSetDilateImageFilter.h
+++ b/include/itkLabelSetDilateImageFilter.h
@@ -76,11 +76,11 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
 
 protected:
-  LabelSetDilateImageFilter() { this->DynamicMultiThreadingOn(); }
+  LabelSetDilateImageFilter() { this->DynamicMultiThreadingOff(); }
   ~LabelSetDilateImageFilter() override = default;
 
   void
-  DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+  ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
 private:
   using DistanceImageType = typename Superclass::DistanceImageType;

--- a/include/itkLabelSetErodeImageFilter.h
+++ b/include/itkLabelSetErodeImageFilter.h
@@ -81,11 +81,11 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
 
 protected:
-  LabelSetErodeImageFilter() { this->DynamicMultiThreadingOn(); }
+  LabelSetErodeImageFilter() { this->DynamicMultiThreadingOff(); }
   ~LabelSetErodeImageFilter() override = default;
 
   void
-  DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+  ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
   // Override since the filter produces the entire dataset.
 private:

--- a/include/itkLabelSetMorphBaseImageFilter.h
+++ b/include/itkLabelSetMorphBaseImageFilter.h
@@ -118,7 +118,7 @@ protected:
   SplitRequestedRegion(RegionIndexType i, RegionIndexType num, OutputImageRegionType & splitRegion) override;
 
   void
-  DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+  ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
   void
   GenerateData() override;

--- a/include/itkLabelSetMorphBaseImageFilter.hxx
+++ b/include/itkLabelSetMorphBaseImageFilter.hxx
@@ -53,17 +53,14 @@ LabelSetMorphBaseImageFilter<TInputImage, doDilate, TOutputImage>::LabelSetMorph
 
   this->SetRadius(1);
 
-  this->DynamicMultiThreadingOn();
+  this->DynamicMultiThreadingOff();
 }
 
 template <typename TInputImage, bool doDilate, typename TOutputImage>
 void
-LabelSetMorphBaseImageFilter<TInputImage, doDilate, TOutputImage>::DynamicThreadedGenerateData(
-  const OutputImageRegionType & outputRegionForThread)
-{
-  // stop warnings
-  (void)outputRegionForThread;
-}
+LabelSetMorphBaseImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGenerateData(
+  const OutputImageRegionType &, ThreadIdType)
+{}
 
 template <typename TInputImage, bool doDilate, typename TOutputImage>
 RegionIndexType

--- a/include/itkLabelSetUtils.h
+++ b/include/itkLabelSetUtils.h
@@ -20,6 +20,7 @@
 
 #include <itkArray.h>
 
+#include "itkProgressReporter.h"
 #include <vector>
 namespace itk
 {
@@ -236,6 +237,7 @@ void
 doOneDimensionErodeFirstPass(TInIter &      inputIterator,
                              TOutDistIter & outputIterator,
                              TOutLabIter &  outputLabIterator,
+                             ProgressReporter & progress,
                              const unsigned LineLength,
                              const unsigned direction,
                              const int      m_MagnitudeSign,
@@ -364,6 +366,7 @@ doOneDimensionErodeFirstPass(TInIter &      inputIterator,
     // now onto the next line
     inputIterator.NextLine();
     outputIterator.NextLine();
+    progress.CompletedPixel();
   }
 }
 
@@ -372,6 +375,7 @@ void
 doOneDimensionDilateFirstPass(TInIter &      inputIterator,
                               TOutDistIter & outputIterator,
                               TOutLabIter &  outputLabIterator,
+                              ProgressReporter & progress,
                               const unsigned LineLength,
                               const unsigned direction,
                               const int      m_MagnitudeSign,
@@ -444,6 +448,7 @@ doOneDimensionDilateFirstPass(TInIter &      inputIterator,
     inputIterator.NextLine();
     outputIterator.NextLine();
     outputLabIterator.NextLine();
+    progress.CompletedPixel();
   }
 }
 
@@ -453,6 +458,7 @@ doOneDimensionErode(TInIter &      inputIterator,
                     TDistIter &    inputDistIterator,
                     TOutDistIter & outputDistIterator,
                     TOutLabIter &  outputLabIterator,
+                    ProgressReporter & progress,
                     const unsigned LineLength,
                     const unsigned direction,
                     const int      m_MagnitudeSign,
@@ -583,6 +589,7 @@ doOneDimensionErode(TInIter &      inputIterator,
     inputIterator.NextLine();
     inputDistIterator.NextLine();
     outputDistIterator.NextLine();
+    progress.CompletedPixel();
   }
 }
 
@@ -592,6 +599,7 @@ doOneDimensionDilate(TInIter &      inputIterator,
                      TDistIter &    inputDistIterator,
                      TOutDistIter & outputDistIterator,
                      TOutLabIter &  outputLabIterator,
+                     ProgressReporter & progress,
                      const unsigned LineLength,
                      const unsigned direction,
                      const int      m_MagnitudeSign,
@@ -663,6 +671,7 @@ doOneDimensionDilate(TInIter &      inputIterator,
     outputLabIterator.NextLine();
     inputDistIterator.NextLine();
     outputDistIterator.NextLine();
+    progress.CompletedPixel();
   }
 }
 } // namespace LabSet

--- a/test/itkLabelSetDilateTest.cxx
+++ b/test/itkLabelSetDilateTest.cxx
@@ -22,11 +22,11 @@
 #include "itkLabelSetDilateImageFilter.h"
 #include "read_info.cxx"
 
-template <class MaskPixType, int dim>
+template <class MaskPixType, int Dim>
 int
 doDilate(char * In, char * Out, int radius)
 {
-  using MaskImType = typename itk::Image<MaskPixType, dim>;
+  using MaskImType = typename itk::Image<MaskPixType, Dim>;
 
   // load
   using ReaderType = typename itk::ImageFileReader<MaskImType>;

--- a/test/itkLabelSetErodeTest.cxx
+++ b/test/itkLabelSetErodeTest.cxx
@@ -23,11 +23,11 @@
 
 #include "read_info.cxx"
 
-template <class MaskPixType, int dim>
+template <class MaskPixType, int Dim>
 int
 doErode(char * In, char * Out, int radius)
 {
-  using MaskImType = typename itk::Image<MaskPixType, dim>;
+  using MaskImType = typename itk::Image<MaskPixType, Dim>;
 
   // load
   using ReaderType = typename itk::ImageFileReader<MaskImType>;


### PR DESCRIPTION
Changing `dim` to `Dim` fixes the failing KWStyle test thrown for this module.

For the filters, these changes address #27. They had to be reverted to the classic ITK multi-threading system, because they utilize a custom region splitter. This required:

- `DynamiicMultThreadingOn()` to `DynamiicMultThreadingOff()` in filter's constructor.

- Changing method `DynamicThreadedGenerateData()` to `ThreadedGenerateData()` with `theadId` passed as a parameter.

    -  Includes progress reporting.

- Adding `ProgressReporter` object as parameter to `doOneDimension()` methods.