### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkLabelSetDilateImageFilter.h
+++ b/include/itkLabelSetDilateImageFilter.h
@@ -40,7 +40,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_EXPORT LabelSetDilateImageFilter : public LabelSetMorphBaseImageFilter<TInputImage, true, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSetDilateImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(LabelSetDilateImageFilter);
 
   /** Standard class type alias. */
   using Self = LabelSetDilateImageFilter;

--- a/include/itkLabelSetErodeImageFilter.h
+++ b/include/itkLabelSetErodeImageFilter.h
@@ -42,7 +42,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_EXPORT LabelSetErodeImageFilter : public LabelSetMorphBaseImageFilter<TInputImage, false, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSetErodeImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(LabelSetErodeImageFilter);
 
   /** Standard class type alias. */
   using Self = LabelSetErodeImageFilter;

--- a/include/itkLabelSetMorphBaseImageFilter.h
+++ b/include/itkLabelSetMorphBaseImageFilter.h
@@ -46,7 +46,7 @@ template <typename TInputImage, bool doDilate, typename TOutputImage = TInputIma
 class ITK_EXPORT LabelSetMorphBaseImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSetMorphBaseImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(LabelSetMorphBaseImageFilter);
 
   /** Standard class type alias. */
   using Self = LabelSetMorphBaseImageFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.