### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkLabelSetDilateImageFilter.hxx
+++ b/include/itkLabelSetDilateImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLabelSetDilateImageFilter_hxx
 #define itkLabelSetDilateImageFilter_hxx
 
-#include "itkLabelSetDilateImageFilter.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/itkLabelSetErodeImageFilter.hxx
+++ b/include/itkLabelSetErodeImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLabelSetErodeImageFilter_hxx
 #define itkLabelSetErodeImageFilter_hxx
 
-#include "itkLabelSetErodeImageFilter.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/itkLabelSetMorphBaseImageFilter.hxx
+++ b/include/itkLabelSetMorphBaseImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLabelSetMorphBaseImageFilter_hxx
 #define itkLabelSetMorphBaseImageFilter_hxx
 
-#include "itkLabelSetMorphBaseImageFilter.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

