### PR TITLE
STYLE: Miscellaneous style improvements to tests

### DIFF
--- a/test/itkLabelSetDilateTest.cxx
+++ b/test/itkLabelSetDilateTest.cxx
@@ -56,16 +56,17 @@ doDilate(char * In, char * Out, int radius)
 int
 itkLabelSetDilateTest(int argc, char * argv[])
 {
-  int dim1;
-
-  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(1);
-  itk::IOComponentEnum ComponentType;
 
   if (argc != 4)
   {
     std::cerr << "Usage: " << argv[0] << "inputimage radius outputimage" << std::endl;
     return (EXIT_FAILURE);
   }
+
+  int dim1;
+
+  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(1);
+  itk::IOComponentEnum ComponentType;
 
   if (!readImageInfo(argv[1], &ComponentType, &dim1))
   {

--- a/test/itkLabelSetDilateTest.cxx
+++ b/test/itkLabelSetDilateTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileWriter.h"
 
 #include "itkLabelSetDilateImageFilter.h"
+#include "itkTestingMacros.h"
 #include "read_info.cxx"
 
 template <class MaskPixType, int Dim>
@@ -32,15 +33,7 @@ doDilate(char * In, char * Out, int radius)
   using ReaderType = typename itk::ImageFileReader<MaskImType>;
   typename ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(In);
-  try
-  {
-    reader->Update();
-  }
-  catch (itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   // Label dilation
   using FilterType = typename itk::LabelSetDilateImageFilter<MaskImType, MaskImType>;
@@ -52,15 +45,8 @@ doDilate(char * In, char * Out, int radius)
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(Out);
-  try
-  {
-    writer->Update();
-  }
-  catch (itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/test/itkLabelSetDilateTest.cxx
+++ b/test/itkLabelSetDilateTest.cxx
@@ -73,7 +73,7 @@ itkLabelSetDilateTest(int argc, char * argv[])
   if (!readImageInfo(argv[1], &ComponentType, &dim1))
   {
     std::cerr << "Failed to open " << argv[1] << std::endl;
-    return (EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
 
   int status = EXIT_FAILURE;
@@ -87,7 +87,7 @@ itkLabelSetDilateTest(int argc, char * argv[])
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      return (EXIT_FAILURE);
+      return EXIT_FAILURE;
       break;
   }
   return status;

--- a/test/itkLabelSetDilateTest.cxx
+++ b/test/itkLabelSetDilateTest.cxx
@@ -51,7 +51,6 @@ doDilate(char * In, char * Out, int radius)
   return EXIT_SUCCESS;
 }
 
-/////////////////////////////////
 
 int
 itkLabelSetDilateTest(int argc, char * argv[])

--- a/test/itkLabelSetDilateTest.cxx
+++ b/test/itkLabelSetDilateTest.cxx
@@ -88,7 +88,6 @@ itkLabelSetDilateTest(int argc, char * argv[])
     default:
       std::cerr << "Unsupported dimension" << std::endl;
       return EXIT_FAILURE;
-      break;
   }
   return status;
 }

--- a/test/itkLabelSetDilateTest.cxx
+++ b/test/itkLabelSetDilateTest.cxx
@@ -59,8 +59,10 @@ itkLabelSetDilateTest(int argc, char * argv[])
 
   if (argc != 4)
   {
-    std::cerr << "Usage: " << argv[0] << "inputimage radius outputimage" << std::endl;
-    return (EXIT_FAILURE);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputimage radius outputimage" << std::endl;
+    return EXIT_FAILURE;
   }
 
   int dim1;

--- a/test/itkLabelSetErodeTest.cxx
+++ b/test/itkLabelSetErodeTest.cxx
@@ -60,8 +60,10 @@ itkLabelSetErodeTest(int argc, char * argv[])
 
   if (argc != 4)
   {
-    std::cerr << "Usage: " << argv[0] << "inputimage radius outputimage" << std::endl;
-    return (EXIT_FAILURE);
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
+    std::cerr << " inputimage radius outputimage" << std::endl;
+    return EXIT_FAILURE;
   }
 
   int dim1;

--- a/test/itkLabelSetErodeTest.cxx
+++ b/test/itkLabelSetErodeTest.cxx
@@ -74,7 +74,7 @@ itkLabelSetErodeTest(int argc, char * argv[])
   if (!readImageInfo(argv[1], &ComponentType, &dim1))
   {
     std::cerr << "Failed to open " << argv[1] << std::endl;
-    return (EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
 
   int status = EXIT_FAILURE;
@@ -88,7 +88,7 @@ itkLabelSetErodeTest(int argc, char * argv[])
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
-      return (EXIT_FAILURE);
+      return EXIT_FAILURE;
       break;
   }
   return status;

--- a/test/itkLabelSetErodeTest.cxx
+++ b/test/itkLabelSetErodeTest.cxx
@@ -57,16 +57,17 @@ doErode(char * In, char * Out, int radius)
 int
 itkLabelSetErodeTest(int argc, char * argv[])
 {
-  int dim1;
-
-  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(1);
-  itk::IOComponentEnum ComponentType;
 
   if (argc != 4)
   {
     std::cerr << "Usage: " << argv[0] << "inputimage radius outputimage" << std::endl;
     return (EXIT_FAILURE);
   }
+
+  int dim1;
+
+  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(1);
+  itk::IOComponentEnum ComponentType;
 
   if (!readImageInfo(argv[1], &ComponentType, &dim1))
   {

--- a/test/itkLabelSetErodeTest.cxx
+++ b/test/itkLabelSetErodeTest.cxx
@@ -52,7 +52,6 @@ doErode(char * In, char * Out, int radius)
   return EXIT_SUCCESS;
 }
 
-/////////////////////////////////////////////
 
 int
 itkLabelSetErodeTest(int argc, char * argv[])

--- a/test/itkLabelSetErodeTest.cxx
+++ b/test/itkLabelSetErodeTest.cxx
@@ -20,6 +20,7 @@
 #include "itkImageFileWriter.h"
 
 #include "itkLabelSetErodeImageFilter.h"
+#include "itkTestingMacros.h"
 
 #include "read_info.cxx"
 
@@ -33,15 +34,7 @@ doErode(char * In, char * Out, int radius)
   using ReaderType = typename itk::ImageFileReader<MaskImType>;
   typename ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(In);
-  try
-  {
-    reader->Update();
-  }
-  catch (itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   // Label dilation
   using FilterType = typename itk::LabelSetErodeImageFilter<MaskImType, MaskImType>;
@@ -53,15 +46,8 @@ doErode(char * In, char * Out, int radius)
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetInput(filter->GetOutput());
   writer->SetFileName(Out);
-  try
-  {
-    writer->Update();
-  }
-  catch (itk::ExceptionObject & excp)
-  {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
+
 
   return EXIT_SUCCESS;
 }

--- a/test/itkLabelSetErodeTest.cxx
+++ b/test/itkLabelSetErodeTest.cxx
@@ -89,7 +89,6 @@ itkLabelSetErodeTest(int argc, char * argv[])
     default:
       std::cerr << "Unsupported dimension" << std::endl;
       return EXIT_FAILURE;
-      break;
   }
   return status;
 }


### PR DESCRIPTION
- STYLE: Use `ITK_TRY_EXPECT_NO_EXCEPTION` macro in tests
- STYLE: Make the input argument checking be the first task in tests
- STYLE: Conform to ITK style guidelines in test arg check
- STYLE: Remove unnecessary brackets around `EXIT_FAILURE`
- STYLE: Remove unreachable break after return statement
- STYLE: Remove unnecessary/empty comment statements in tests