### PR TITLE
STYLE: Conform to ITK local variable naming style

### DIFF
--- a/include/itkLabelSetUtils.h
+++ b/include/itkLabelSetUtils.h
@@ -28,70 +28,70 @@ namespace LabSet
 {
 template <class LineBufferType, class RealType>
 void
-DoLineErodeFirstPass(LineBufferType & LineBuf,
+DoLineErodeFirstPass(LineBufferType & lineBuf,
                      RealType         leftend,
                      RealType         rightend,
                      const RealType   magnitude,
-                     const RealType   Sigma)
+                     const RealType   sigma)
 {
   // This is the first pass algorithm. We can write down the values
   // because we know the inputs are binary
 
-  const long LineLength = LineBuf.size();
+  const long lineLength = lineBuf.size();
 
-  for (long pos = 0; pos < LineLength; pos++)
+  for (long pos = 0; pos < lineLength; pos++)
   {
     // compute the height of the parabola starting at each end and
     // keep the minimum
     RealType left, right;
-    unsigned offset = LineLength - pos;
+    unsigned offset = lineLength - pos;
     left = leftend - magnitude * (pos + 1) * (pos + 1);
     right = rightend - magnitude * offset * offset;
     // note hard coded value here - could be a parameter
-    //    LineBuf[pos] = std::min(std::min(left, right),
+    //    lineBuf[pos] = std::min(std::min(left, right),
     // itk::NumericTraits<RealType>::One);
-    LineBuf[pos] = std::min(std::min(left, right), Sigma);
+    lineBuf[pos] = std::min(std::min(left, right), sigma);
   }
 }
 
 template <class LineBufferType, class LabLineBufferType, class RealType>
 void
-DoLineDilateFirstPass(LineBufferType &    LineBuf,
+DoLineDilateFirstPass(LineBufferType &    lineBuf,
                       LineBufferType &    tmpLineBuf,
-                      LabLineBufferType & LabBuf,
+                      LabLineBufferType & labBuf,
                       LabLineBufferType & NewLabBuf,
                       const RealType      magnitude)
 {
   // need to propagate the labels here
-  const long LineLength = LineBuf.size();
+  const long lineLength = lineBuf.size();
   long       lastcontact = 0;
-  RealType   lastval = LineBuf[0];
+  RealType   lastval = lineBuf[0];
 
-  for (long pos = 0; pos < LineLength; pos++)
+  for (long pos = 0; pos < lineLength; pos++)
   {
     // left pass
     RealType krange = pos - lastcontact;
     RealType thisval = lastval - magnitude * krange * krange;
 
-    if (LineBuf[pos] >= LineBuf[lastcontact])
+    if (lineBuf[pos] >= lineBuf[lastcontact])
     {
       lastcontact = pos;
-      lastval = LineBuf[pos];
+      lastval = lineBuf[pos];
     }
-    tmpLineBuf[pos] = std::max(LineBuf[pos], thisval);
-    if (thisval > LineBuf[pos])
+    tmpLineBuf[pos] = std::max(lineBuf[pos], thisval);
+    if (thisval > lineBuf[pos])
     {
-      NewLabBuf[pos] = LabBuf[lastcontact];
+      NewLabBuf[pos] = labBuf[lastcontact];
     }
     else
     {
-      NewLabBuf[pos] = LabBuf[pos];
+      NewLabBuf[pos] = labBuf[pos];
     }
   }
 
-  lastcontact = LineLength - 1;
+  lastcontact = lineLength - 1;
   lastval = tmpLineBuf[lastcontact];
-  for (long pos = LineLength - 1; pos >= 0; pos--)
+  for (long pos = lineLength - 1; pos >= 0; pos--)
   {
     // right pass
     RealType krange = lastcontact - pos;
@@ -102,72 +102,71 @@ DoLineDilateFirstPass(LineBufferType &    LineBuf,
       lastcontact = pos;
       lastval = tmpLineBuf[pos];
     }
-    LineBuf[pos] = std::max(tmpLineBuf[pos], thisval);
+    lineBuf[pos] = std::max(tmpLineBuf[pos], thisval);
     if (thisval > tmpLineBuf[pos])
     {
-      NewLabBuf[pos] = LabBuf[lastcontact];
+      NewLabBuf[pos] = labBuf[lastcontact];
     }
     // only need to do this bit on the first pass - it doubles as a
     // way of initializing NewLabPos
     // else
     //   {
-    //   NewLabBuf[pos] = LabBuf[pos];
+    //   NewLabBuf[pos] = labBuf[pos];
     //   }
   }
 }
 
 template <class LineBufferType, class RealType, bool doDilate>
 void
-DoLine(LineBufferType & LineBuf, LineBufferType & tmpLineBuf, const RealType magnitude, const RealType m_Extreme)
+DoLine(LineBufferType & lineBuf, LineBufferType & tmpLineBuf, const RealType magnitude, const RealType m_Extreme)
 {
   // contact point algorithm
   long koffset = 0, newcontact = 0; // how far away the search starts.
 
-  const long LineLength = LineBuf.size();
+  const long lineLength = lineBuf.size();
 
   // negative half of the parabola
-  for (long pos = 0; pos < LineLength; pos++)
+  for (long pos = 0; pos < lineLength; pos++)
   {
-    auto BaseVal = (RealType)m_Extreme; // the base value for
-                                        // comparison
+    auto baseVal = (RealType)m_Extreme; // the base value for comparison
     for (long krange = koffset; krange <= 0; krange++)
     {
       // difference needs to be paramaterised
-      RealType T = LineBuf[pos + krange] - magnitude * krange * krange;
+      RealType T = lineBuf[pos + krange] - magnitude * krange * krange;
       // switch on template parameter - hopefully gets optimized away.
-      if (doDilate ? (T >= BaseVal) : (T <= BaseVal))
+      if (doDilate ? (T >= baseVal) : (T <= baseVal))
       {
-        BaseVal = T;
+        baseVal = T;
         newcontact = krange;
       }
     }
-    tmpLineBuf[pos] = BaseVal;
+    tmpLineBuf[pos] = baseVal;
     koffset = newcontact - 1;
   }
   // positive half of parabola
   koffset = newcontact = 0;
-  for (long pos = LineLength - 1; pos >= 0; pos--)
+  for (long pos = lineLength - 1; pos >= 0; pos--)
   {
-    auto BaseVal = (RealType)m_Extreme; // the base value for comparison
+    auto baseVal = (RealType)m_Extreme; // the base value for comparison
     for (long krange = koffset; krange >= 0; krange--)
     {
       RealType T = tmpLineBuf[pos + krange] - magnitude * krange * krange;
-      if (doDilate ? (T >= BaseVal) : (T <= BaseVal))
+      if (doDilate ? (T >= baseVal) : (T <= baseVal))
       {
-        BaseVal = T;
+        baseVal = T;
         newcontact = krange;
       }
     }
-    LineBuf[pos] = BaseVal;
+    lineBuf[pos] = baseVal;
     koffset = newcontact + 1;
   }
 }
 
 template <class LineBufferType, class LabBufferType, class RealType, bool doDilate>
 void
-DoLineLabelProp(LineBufferType & LineBuf,
+DoLineLabelProp(LineBufferType & lineBuf,
                 LineBufferType & tmpLineBuf,
-                LabBufferType &  LabelBuf,
+                LabBufferType &  labelBuf,
                 LabBufferType &  tmpLabelBuf,
                 const RealType   magnitude,
                 const RealType   m_Extreme)
@@ -177,56 +176,55 @@ DoLineLabelProp(LineBufferType & LineBuf,
 
   using LabelType = typename LabBufferType::ValueType;
 
-  const long LineLength = LineBuf.size();
+  const long lineLength = lineBuf.size();
   // negative half of the parabola
-  for (long pos = 0; pos < LineLength; pos++)
+  for (long pos = 0; pos < lineLength; pos++)
   {
-    auto BaseVal = (RealType)m_Extreme; // the base value for
-                                        // comparison
-    LabelType BaseLab = LabelBuf[pos];
+    auto      baseVal = (RealType)m_Extreme; // the base value for comparison
+    LabelType baseLab = labelBuf[pos];
     for (long krange = koffset; krange <= 0; krange++)
     {
       // difference needs to be paramaterised
-      RealType T = LineBuf[pos + krange] - magnitude * krange * krange;
+      RealType T = lineBuf[pos + krange] - magnitude * krange * krange;
       // switch on template parameter - hopefully gets optimized away.
-      if (doDilate ? (T >= BaseVal) : (T <= BaseVal))
+      if (doDilate ? (T >= baseVal) : (T <= baseVal))
       {
-        BaseVal = T;
+        baseVal = T;
         newcontact = krange;
-        BaseLab = LabelBuf[pos + krange];
+        baseLab = labelBuf[pos + krange];
       }
     }
-    tmpLineBuf[pos] = BaseVal;
-    tmpLabelBuf[pos] = BaseLab;
+    tmpLineBuf[pos] = baseVal;
+    tmpLabelBuf[pos] = baseLab;
     koffset = newcontact - 1;
   }
   // positive half of parabola
   koffset = newcontact = 0;
 #if 1
-  for (long pos = LineLength - 1; pos >= 0; pos--)
+  for (long pos = lineLength - 1; pos >= 0; pos--)
   {
-    auto BaseVal = (RealType)m_Extreme; // the base value for comparison
+    auto baseVal = (RealType)m_Extreme; // the base value for comparison
     // initialize the label to the previously pro
-    LabelType BaseLab = tmpLabelBuf[pos];
+    LabelType baseLab = tmpLabelBuf[pos];
     for (long krange = koffset; krange >= 0; krange--)
     {
       RealType T = tmpLineBuf[pos + krange] - magnitude * krange * krange;
-      if (doDilate ? (T >= BaseVal) : (T <= BaseVal))
+      if (doDilate ? (T >= baseVal) : (T <= baseVal))
       {
-        BaseVal = T;
+        baseVal = T;
         newcontact = krange;
-        BaseLab = tmpLabelBuf[pos + krange];
+        baseLab = tmpLabelBuf[pos + krange];
       }
     }
-    LineBuf[pos] = BaseVal;
-    LabelBuf[pos] = BaseLab;
+    lineBuf[pos] = baseVal;
+    labelBuf[pos] = baseLab;
     koffset = newcontact + 1;
   }
 #else
-  for (long pos = LineLength - 1; pos >= 0; pos--)
+  for (long pos = lineLength - 1; pos >= 0; pos--)
   {
-    LineBuf[pos] = tmpLineBuf[pos];
-    LabelBuf[pos] = tmpLabelBuf[pos];
+    lineBuf[pos] = tmpLineBuf[pos];
+    labelBuf[pos] = tmpLabelBuf[pos];
   }
 
 #endif
@@ -238,12 +236,12 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
                              TOutDistIter &     outputIterator,
                              TOutLabIter &      outputLabIterator,
                              ProgressReporter & progress,
-                             const unsigned     LineLength,
+                             const unsigned     lineLength,
                              const unsigned     direction,
                              const int          m_MagnitudeSign,
                              const bool         m_UseImageSpacing,
                              const RealType     image_scale,
-                             const RealType     Sigma,
+                             const RealType     sigma,
                              const bool         lastpass)
 {
   // specialised version for binary erosion during first pass. We can
@@ -257,10 +255,10 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
   }
   // restructure equation to reduce numerical error
   //  const RealType magnitude = (m_MagnitudeSign * iscale * iscale)/(2.0 *
-  // Sigma);
+  // sigma);
   const RealType  magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0);
-  LineBufferType  LineBuf(LineLength);
-  LabelBufferType LabBuf(LineLength);
+  LineBufferType  lineBuf(lineLength);
+  LabelBufferType labBuf(lineLength);
 
   inputIterator.SetDirection(direction);
   outputIterator.SetDirection(direction);
@@ -280,10 +278,10 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
     // copy the scanline to a buffer
     while (!inputIterator.IsAtEndOfLine())
     {
-      LabBuf[i] = (inputIterator.Get());
-      if (LabBuf[i])
+      labBuf[i] = (inputIterator.Get());
+      if (labBuf[i])
       {
-        LineBuf[i] = 1.0;
+        lineBuf[i] = 1.0;
       }
       ++i;
       ++inputIterator;
@@ -294,17 +292,17 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
     EndType firsts;
     EndType lasts;
 
-    for (unsigned idx = 0; idx < LineLength; idx++)
+    for (unsigned idx = 0; idx < lineLength; idx++)
     {
-      RealType val = LabBuf[idx];
+      RealType val = labBuf[idx];
       if (val != 0)
       {
         // found a run
         firsts.push_back(idx);
         unsigned idxend = idx;
-        for (; idxend < LineLength; idxend++)
+        for (; idxend < lineLength; idxend++)
         {
-          if (val != LabBuf[idxend])
+          if (val != labBuf[idxend])
           {
             break;
           }
@@ -325,22 +323,22 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
       RealType leftend = 0, rightend = 0;
       if (first == 0)
       {
-        leftend = Sigma;
+        leftend = sigma;
       }
-      if (last == LineLength - 1)
+      if (last == lineLength - 1)
       {
-        rightend = Sigma;
+        rightend = sigma;
       }
 
-      DoLineErodeFirstPass<LineBufferType, RealType>(ShortLineBuf, leftend, rightend, magnitude, Sigma);
+      DoLineErodeFirstPass<LineBufferType, RealType>(ShortLineBuf, leftend, rightend, magnitude, sigma);
       // copy the segment back into the full line buffer
-      std::copy(ShortLineBuf.begin(), ShortLineBuf.end(), &(LineBuf[first]));
+      std::copy(ShortLineBuf.begin(), ShortLineBuf.end(), &(lineBuf[first]));
     }
     // copy the line buffer back to the image
     unsigned j = 0;
     while (!outputIterator.IsAtEndOfLine())
     {
-      outputIterator.Set(static_cast<typename TOutDistIter::PixelType>(LineBuf[j++]));
+      outputIterator.Set(static_cast<typename TOutDistIter::PixelType>(lineBuf[j++]));
       ++outputIterator;
     }
 
@@ -352,9 +350,9 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
       while (!outputLabIterator.IsAtEndOfLine())
       {
         typename TInIter::PixelType val = 0;
-        if (LineBuf[j2] == Sigma)
+        if (lineBuf[j2] == sigma)
         {
-          val = LabBuf[j2];
+          val = labBuf[j2];
         }
         outputLabIterator.Set(val);
         ++outputLabIterator;
@@ -376,12 +374,12 @@ doOneDimensionDilateFirstPass(TInIter &          inputIterator,
                               TOutDistIter &     outputIterator,
                               TOutLabIter &      outputLabIterator,
                               ProgressReporter & progress,
-                              const unsigned     LineLength,
+                              const unsigned     lineLength,
                               const unsigned     direction,
                               const int          m_MagnitudeSign,
                               const bool         m_UseImageSpacing,
                               const RealType     image_scale,
-                              const RealType     Sigma)
+                              const RealType     sigma)
 {
   // specialised version for binary erosion during first pass. We can
   // compute the results directly because the inputs are flat.
@@ -394,12 +392,12 @@ doOneDimensionDilateFirstPass(TInIter &          inputIterator,
   }
   // restructure equation to reduce numerical error
   // const RealType magnitude = (m_MagnitudeSign * iscale * iscale)/(2.0 *
-  // Sigma);
+  // sigma);
   const RealType  magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0);
-  LineBufferType  LineBuf(LineLength);
-  LabelBufferType LabBuf(LineLength);
-  LineBufferType  tmpLineBuf(LineLength);
-  LabelBufferType newLabBuf(LineLength);
+  LineBufferType  lineBuf(lineLength);
+  LabelBufferType labBuf(lineLength);
+  LineBufferType  tmpLineBuf(lineLength);
+  LabelBufferType newLabBuf(lineLength);
 
   inputIterator.SetDirection(direction);
   outputIterator.SetDirection(direction);
@@ -419,25 +417,25 @@ doOneDimensionDilateFirstPass(TInIter &          inputIterator,
     // copy the scanline to a buffer
     while (!inputIterator.IsAtEndOfLine())
     {
-      LabBuf[i] = (inputIterator.Get());
-      if (LabBuf[i])
+      labBuf[i] = (inputIterator.Get());
+      if (labBuf[i])
       {
-        LineBuf[i] = Sigma;
+        lineBuf[i] = sigma;
       }
       else
       {
-        LineBuf[i] = 0;
+        lineBuf[i] = 0;
       }
       ++i;
       ++inputIterator;
     }
 
-    DoLineDilateFirstPass<LineBufferType, LabelBufferType, RealType>(LineBuf, tmpLineBuf, LabBuf, newLabBuf, magnitude);
+    DoLineDilateFirstPass<LineBufferType, LabelBufferType, RealType>(lineBuf, tmpLineBuf, labBuf, newLabBuf, magnitude);
     // copy the line buffer back to the image
     unsigned j = 0;
     while (!outputIterator.IsAtEndOfLine())
     {
-      outputIterator.Set(static_cast<typename TOutDistIter::PixelType>(LineBuf[j]));
+      outputIterator.Set(static_cast<typename TOutDistIter::PixelType>(lineBuf[j]));
       outputLabIterator.Set(newLabBuf[j]);
       ++outputLabIterator;
       ++outputIterator;
@@ -459,13 +457,13 @@ doOneDimensionErode(TInIter &          inputIterator,
                     TOutDistIter &     outputDistIterator,
                     TOutLabIter &      outputLabIterator,
                     ProgressReporter & progress,
-                    const unsigned     LineLength,
+                    const unsigned     lineLength,
                     const unsigned     direction,
                     const int          m_MagnitudeSign,
                     const bool         m_UseImageSpacing,
                     const RealType     m_Extreme,
                     const RealType     image_scale,
-                    const RealType     Sigma,
+                    const RealType     sigma,
                     const RealType     BaseSigma,
                     const bool         lastpass)
 {
@@ -477,9 +475,9 @@ doOneDimensionErode(TInIter &          inputIterator,
   {
     iscale = image_scale;
   }
-  const RealType  magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0 * Sigma);
-  LineBufferType  LineBuf(LineLength);
-  LabelBufferType LabBuf(LineLength);
+  const RealType  magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0 * sigma);
+  LineBufferType  lineBuf(lineLength);
+  LabelBufferType labBuf(lineLength);
 
   inputIterator.SetDirection(direction);
   outputDistIterator.SetDirection(direction);
@@ -501,8 +499,8 @@ doOneDimensionErode(TInIter &          inputIterator,
     // copy the scanline to a buffer
     while (!inputIterator.IsAtEndOfLine())
     {
-      LineBuf[i] = static_cast<RealType>(inputDistIterator.Get());
-      LabBuf[i] = inputIterator.Get();
+      lineBuf[i] = static_cast<RealType>(inputDistIterator.Get());
+      labBuf[i] = inputIterator.Get();
       ++i;
       ++inputDistIterator;
       ++inputIterator;
@@ -511,17 +509,17 @@ doOneDimensionErode(TInIter &          inputIterator,
     using EndType = std::vector<unsigned>;
     EndType firsts;
     EndType lasts;
-    for (unsigned idx = 0; idx < LineLength; idx++)
+    for (unsigned idx = 0; idx < lineLength; idx++)
     {
-      RealType val = LabBuf[idx];
+      RealType val = labBuf[idx];
       if (val != 0)
       {
         // found a run
         firsts.push_back(idx);
         unsigned idxend = idx;
-        for (; idxend < LineLength; idxend++)
+        for (; idxend < lineLength; idxend++)
         {
-          if (val != LabBuf[idxend])
+          if (val != labBuf[idxend])
           {
             break;
           }
@@ -546,7 +544,7 @@ doOneDimensionErode(TInIter &          inputIterator,
       {
         leftend = BaseSigma;
       }
-      if (last == LineLength - 1)
+      if (last == lineLength - 1)
       {
         rightend = BaseSigma;
       }
@@ -554,18 +552,18 @@ doOneDimensionErode(TInIter &          inputIterator,
       ShortLineBuf[0] = leftend;
       ShortLineBuf[SLL + 1] = rightend;
 
-      std::copy(&(LineBuf[first]), &(LineBuf[last + 1]), &(ShortLineBuf[1]));
+      std::copy(&(lineBuf[first]), &(lineBuf[last + 1]), &(ShortLineBuf[1]));
 
       DoLine<LineBufferType, RealType, false>(ShortLineBuf, tmpShortLineBuf, magnitude, m_Extreme);
       // copy the segment back into the full line buffer
-      std::copy(&(ShortLineBuf[1]), &(ShortLineBuf[SLL + 1]), &(LineBuf[first]));
+      std::copy(&(ShortLineBuf[1]), &(ShortLineBuf[SLL + 1]), &(lineBuf[first]));
     }
     // copy the line buffer back to the image - don't need to do it on
     // the last pass - move when we are sure it is working
     unsigned j = 0;
     while (!outputDistIterator.IsAtEndOfLine())
     {
-      outputDistIterator.Set(static_cast<typename TOutDistIter::PixelType>(LineBuf[j++]));
+      outputDistIterator.Set(static_cast<typename TOutDistIter::PixelType>(lineBuf[j++]));
       ++outputDistIterator;
     }
 
@@ -575,9 +573,9 @@ doOneDimensionErode(TInIter &          inputIterator,
       while (!outputLabIterator.IsAtEndOfLine())
       {
         typename TInIter::PixelType val = 0;
-        if (LineBuf[j2] == BaseSigma)
+        if (lineBuf[j2] == BaseSigma)
         {
-          val = LabBuf[j2];
+          val = labBuf[j2];
         }
         outputLabIterator.Set(val);
         ++outputLabIterator;
@@ -600,13 +598,13 @@ doOneDimensionDilate(TInIter &          inputIterator,
                      TOutDistIter &     outputDistIterator,
                      TOutLabIter &      outputLabIterator,
                      ProgressReporter & progress,
-                     const unsigned     LineLength,
+                     const unsigned     lineLength,
                      const unsigned     direction,
                      const int          m_MagnitudeSign,
                      const bool         m_UseImageSpacing,
                      const RealType     m_Extreme,
                      const RealType     image_scale,
-                     const RealType     Sigma)
+                     const RealType     sigma)
 {
   // specialised version for binary erosion during first pass. We can
   // compute the results directly because the inputs are flat.
@@ -618,13 +616,13 @@ doOneDimensionDilate(TInIter &          inputIterator,
     iscale = image_scale;
   }
   // restructure equation to reduce numerical error
-  const RealType magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0 * Sigma);
+  const RealType magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0 * sigma);
   //  const RealType magnitude = (m_MagnitudeSign * iscale * iscale)/(2.0 );
-  LineBufferType  LineBuf(LineLength);
-  LabelBufferType LabBuf(LineLength);
-  LineBufferType  tmpLineBuf(LineLength);
-  LabelBufferType newLabBuf(LineLength);
-  LabelBufferType tmpLabBuf(LineLength);
+  LineBufferType  lineBuf(lineLength);
+  LabelBufferType labBuf(lineLength);
+  LineBufferType  tmpLineBuf(lineLength);
+  LabelBufferType newLabBuf(lineLength);
+  LabelBufferType tmpLabBuf(lineLength);
 
   inputIterator.SetDirection(direction);
   inputDistIterator.SetDirection(direction);
@@ -646,21 +644,21 @@ doOneDimensionDilate(TInIter &          inputIterator,
     // copy the scanline to a buffer
     while (!inputDistIterator.IsAtEndOfLine())
     {
-      LineBuf[i] = inputDistIterator.Get();
-      LabBuf[i] = inputIterator.Get();
+      lineBuf[i] = inputDistIterator.Get();
+      labBuf[i] = inputIterator.Get();
       ++i;
       ++inputIterator;
       ++inputDistIterator;
     }
 
     DoLineLabelProp<LineBufferType, LabelBufferType, RealType, true>(
-      LineBuf, tmpLineBuf, LabBuf, tmpLabBuf, magnitude, m_Extreme);
+      lineBuf, tmpLineBuf, labBuf, tmpLabBuf, magnitude, m_Extreme);
     // copy the line buffer back to the image
     unsigned j = 0;
     while (!outputDistIterator.IsAtEndOfLine())
     {
-      outputDistIterator.Set(static_cast<typename TOutDistIter::PixelType>(LineBuf[j]));
-      outputLabIterator.Set(LabBuf[j]);
+      outputDistIterator.Set(static_cast<typename TOutDistIter::PixelType>(lineBuf[j]));
+      outputLabIterator.Set(labBuf[j]);
       ++outputDistIterator;
       ++outputLabIterator;
       j++;

--- a/include/itkLabelSetUtils.h
+++ b/include/itkLabelSetUtils.h
@@ -118,7 +118,7 @@ DoLineDilateFirstPass(LineBufferType &    lineBuf,
 
 template <class LineBufferType, class RealType, bool doDilate>
 void
-DoLine(LineBufferType & lineBuf, LineBufferType & tmpLineBuf, const RealType magnitude, const RealType m_Extreme)
+DoLine(LineBufferType & lineBuf, LineBufferType & tmpLineBuf, const RealType magnitude, const RealType extreme)
 {
   // contact point algorithm
   long koffset = 0, newcontact = 0; // how far away the search starts.
@@ -128,7 +128,7 @@ DoLine(LineBufferType & lineBuf, LineBufferType & tmpLineBuf, const RealType mag
   // negative half of the parabola
   for (long pos = 0; pos < lineLength; pos++)
   {
-    auto baseVal = (RealType)m_Extreme; // the base value for comparison
+    auto baseVal = (RealType)extreme; // the base value for comparison
     for (long krange = koffset; krange <= 0; krange++)
     {
       // difference needs to be paramaterised
@@ -147,7 +147,7 @@ DoLine(LineBufferType & lineBuf, LineBufferType & tmpLineBuf, const RealType mag
   koffset = newcontact = 0;
   for (long pos = lineLength - 1; pos >= 0; pos--)
   {
-    auto baseVal = (RealType)m_Extreme; // the base value for comparison
+    auto baseVal = (RealType)extreme; // the base value for comparison
     for (long krange = koffset; krange >= 0; krange--)
     {
       RealType T = tmpLineBuf[pos + krange] - magnitude * krange * krange;
@@ -169,7 +169,7 @@ DoLineLabelProp(LineBufferType & lineBuf,
                 LabBufferType &  labelBuf,
                 LabBufferType &  tmpLabelBuf,
                 const RealType   magnitude,
-                const RealType   m_Extreme)
+                const RealType   extreme)
 {
   // contact point algorithm
   long koffset = 0, newcontact = 0; // how far away the search starts.
@@ -180,7 +180,7 @@ DoLineLabelProp(LineBufferType & lineBuf,
   // negative half of the parabola
   for (long pos = 0; pos < lineLength; pos++)
   {
-    auto      baseVal = (RealType)m_Extreme; // the base value for comparison
+    auto      baseVal = (RealType)extreme; // the base value for comparison
     LabelType baseLab = labelBuf[pos];
     for (long krange = koffset; krange <= 0; krange++)
     {
@@ -203,7 +203,7 @@ DoLineLabelProp(LineBufferType & lineBuf,
 #if 1
   for (long pos = lineLength - 1; pos >= 0; pos--)
   {
-    auto baseVal = (RealType)m_Extreme; // the base value for comparison
+    auto baseVal = (RealType)extreme; // the base value for comparison
     // initialize the label to the previously pro
     LabelType baseLab = tmpLabelBuf[pos];
     for (long krange = koffset; krange >= 0; krange--)
@@ -238,8 +238,8 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
                              ProgressReporter & progress,
                              const unsigned     lineLength,
                              const unsigned     direction,
-                             const int          m_MagnitudeSign,
-                             const bool         m_UseImageSpacing,
+                             const int          magnitudeSign,
+                             const bool         useImageSpacing,
                              const RealType     image_scale,
                              const RealType     sigma,
                              const bool         lastpass)
@@ -249,14 +249,14 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
   using LineBufferType = typename itk::Array<RealType>;
   using LabelBufferType = typename itk::Array<typename TInIter::PixelType>;
   RealType iscale = 1.0;
-  if (m_UseImageSpacing)
+  if (useImageSpacing)
   {
     iscale = image_scale;
   }
   // restructure equation to reduce numerical error
-  //  const RealType magnitude = (m_MagnitudeSign * iscale * iscale)/(2.0 *
+  //  const RealType magnitude = (magnitudeSign * iscale * iscale)/(2.0 *
   // sigma);
-  const RealType  magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0);
+  const RealType  magnitude = (magnitudeSign * iscale * iscale) / (2.0);
   LineBufferType  lineBuf(lineLength);
   LabelBufferType labBuf(lineLength);
 
@@ -376,8 +376,8 @@ doOneDimensionDilateFirstPass(TInIter &          inputIterator,
                               ProgressReporter & progress,
                               const unsigned     lineLength,
                               const unsigned     direction,
-                              const int          m_MagnitudeSign,
-                              const bool         m_UseImageSpacing,
+                              const int          magnitudeSign,
+                              const bool         useImageSpacing,
                               const RealType     image_scale,
                               const RealType     sigma)
 {
@@ -386,14 +386,14 @@ doOneDimensionDilateFirstPass(TInIter &          inputIterator,
   using LineBufferType = typename itk::Array<RealType>;
   using LabelBufferType = typename itk::Array<typename TInIter::PixelType>;
   RealType iscale = 1.0;
-  if (m_UseImageSpacing)
+  if (useImageSpacing)
   {
     iscale = image_scale;
   }
   // restructure equation to reduce numerical error
-  // const RealType magnitude = (m_MagnitudeSign * iscale * iscale)/(2.0 *
+  // const RealType magnitude = (magnitudeSign * iscale * iscale)/(2.0 *
   // sigma);
-  const RealType  magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0);
+  const RealType  magnitude = (magnitudeSign * iscale * iscale) / (2.0);
   LineBufferType  lineBuf(lineLength);
   LabelBufferType labBuf(lineLength);
   LineBufferType  tmpLineBuf(lineLength);
@@ -459,9 +459,9 @@ doOneDimensionErode(TInIter &          inputIterator,
                     ProgressReporter & progress,
                     const unsigned     lineLength,
                     const unsigned     direction,
-                    const int          m_MagnitudeSign,
-                    const bool         m_UseImageSpacing,
-                    const RealType     m_Extreme,
+                    const int          magnitudeSign,
+                    const bool         useImageSpacing,
+                    const RealType     extreme,
                     const RealType     image_scale,
                     const RealType     sigma,
                     const RealType     BaseSigma,
@@ -471,11 +471,11 @@ doOneDimensionErode(TInIter &          inputIterator,
   using LineBufferType = typename itk::Array<RealType>;
   using LabelBufferType = typename itk::Array<typename TInIter::PixelType>;
   RealType iscale = 1.0;
-  if (m_UseImageSpacing)
+  if (useImageSpacing)
   {
     iscale = image_scale;
   }
-  const RealType  magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0 * sigma);
+  const RealType  magnitude = (magnitudeSign * iscale * iscale) / (2.0 * sigma);
   LineBufferType  lineBuf(lineLength);
   LabelBufferType labBuf(lineLength);
 
@@ -554,7 +554,7 @@ doOneDimensionErode(TInIter &          inputIterator,
 
       std::copy(&(lineBuf[first]), &(lineBuf[last + 1]), &(ShortLineBuf[1]));
 
-      DoLine<LineBufferType, RealType, false>(ShortLineBuf, tmpShortLineBuf, magnitude, m_Extreme);
+      DoLine<LineBufferType, RealType, false>(ShortLineBuf, tmpShortLineBuf, magnitude, extreme);
       // copy the segment back into the full line buffer
       std::copy(&(ShortLineBuf[1]), &(ShortLineBuf[SLL + 1]), &(lineBuf[first]));
     }
@@ -600,9 +600,9 @@ doOneDimensionDilate(TInIter &          inputIterator,
                      ProgressReporter & progress,
                      const unsigned     lineLength,
                      const unsigned     direction,
-                     const int          m_MagnitudeSign,
-                     const bool         m_UseImageSpacing,
-                     const RealType     m_Extreme,
+                     const int          magnitudeSign,
+                     const bool         useImageSpacing,
+                     const RealType     extreme,
                      const RealType     image_scale,
                      const RealType     sigma)
 {
@@ -611,13 +611,13 @@ doOneDimensionDilate(TInIter &          inputIterator,
   using LineBufferType = typename itk::Array<RealType>;
   using LabelBufferType = typename itk::Array<typename TInIter::PixelType>;
   RealType iscale = 1.0;
-  if (m_UseImageSpacing)
+  if (useImageSpacing)
   {
     iscale = image_scale;
   }
   // restructure equation to reduce numerical error
-  const RealType magnitude = (m_MagnitudeSign * iscale * iscale) / (2.0 * sigma);
-  //  const RealType magnitude = (m_MagnitudeSign * iscale * iscale)/(2.0 );
+  const RealType magnitude = (magnitudeSign * iscale * iscale) / (2.0 * sigma);
+  //  const RealType magnitude = (magnitudeSign * iscale * iscale)/(2.0 );
   LineBufferType  lineBuf(lineLength);
   LabelBufferType labBuf(lineLength);
   LineBufferType  tmpLineBuf(lineLength);
@@ -652,7 +652,7 @@ doOneDimensionDilate(TInIter &          inputIterator,
     }
 
     DoLineLabelProp<LineBufferType, LabelBufferType, RealType, true>(
-      lineBuf, tmpLineBuf, labBuf, tmpLabBuf, magnitude, m_Extreme);
+      lineBuf, tmpLineBuf, labBuf, tmpLabBuf, magnitude, extreme);
     // copy the line buffer back to the image
     unsigned j = 0;
     while (!outputDistIterator.IsAtEndOfLine())

--- a/include/itkLabelSetUtils.h
+++ b/include/itkLabelSetUtils.h
@@ -240,7 +240,7 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
                              const unsigned     direction,
                              const int          magnitudeSign,
                              const bool         useImageSpacing,
-                             const RealType     image_scale,
+                             const RealType     imageScale,
                              const RealType     sigma,
                              const bool         lastpass)
 {
@@ -251,7 +251,7 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
   RealType iscale = 1.0;
   if (useImageSpacing)
   {
-    iscale = image_scale;
+    iscale = imageScale;
   }
   // restructure equation to reduce numerical error
   //  const RealType magnitude = (magnitudeSign * iscale * iscale)/(2.0 *
@@ -378,7 +378,7 @@ doOneDimensionDilateFirstPass(TInIter &          inputIterator,
                               const unsigned     direction,
                               const int          magnitudeSign,
                               const bool         useImageSpacing,
-                              const RealType     image_scale,
+                              const RealType     imageScale,
                               const RealType     sigma)
 {
   // specialised version for binary erosion during first pass. We can
@@ -388,7 +388,7 @@ doOneDimensionDilateFirstPass(TInIter &          inputIterator,
   RealType iscale = 1.0;
   if (useImageSpacing)
   {
-    iscale = image_scale;
+    iscale = imageScale;
   }
   // restructure equation to reduce numerical error
   // const RealType magnitude = (magnitudeSign * iscale * iscale)/(2.0 *
@@ -462,7 +462,7 @@ doOneDimensionErode(TInIter &          inputIterator,
                     const int          magnitudeSign,
                     const bool         useImageSpacing,
                     const RealType     extreme,
-                    const RealType     image_scale,
+                    const RealType     imageScale,
                     const RealType     sigma,
                     const RealType     BaseSigma,
                     const bool         lastpass)
@@ -473,7 +473,7 @@ doOneDimensionErode(TInIter &          inputIterator,
   RealType iscale = 1.0;
   if (useImageSpacing)
   {
-    iscale = image_scale;
+    iscale = imageScale;
   }
   const RealType  magnitude = (magnitudeSign * iscale * iscale) / (2.0 * sigma);
   LineBufferType  lineBuf(lineLength);
@@ -603,7 +603,7 @@ doOneDimensionDilate(TInIter &          inputIterator,
                      const int          magnitudeSign,
                      const bool         useImageSpacing,
                      const RealType     extreme,
-                     const RealType     image_scale,
+                     const RealType     imageScale,
                      const RealType     sigma)
 {
   // specialised version for binary erosion during first pass. We can
@@ -613,7 +613,7 @@ doOneDimensionDilate(TInIter &          inputIterator,
   RealType iscale = 1.0;
   if (useImageSpacing)
   {
-    iscale = image_scale;
+    iscale = imageScale;
   }
   // restructure equation to reduce numerical error
   const RealType magnitude = (magnitudeSign * iscale * iscale) / (2.0 * sigma);


### PR DESCRIPTION
- STYLE: Conform to ITK style guidelines in local variable naming
- STYLE: Do no use `m_` to start function parameter names
- STYLE: Use medial capitals for variable naming in C++ code