### PR TITLE
BUG: Fix Valgrind defect with uninitialized array in doOneDimensionErode

### DIFF
--- a/include/itkLabelSetUtils.h
+++ b/include/itkLabelSetUtils.h
@@ -257,7 +257,7 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
   //  const RealType magnitude = (magnitudeSign * iscale * iscale)/(2.0 *
   // sigma);
   const RealType  magnitude = (magnitudeSign * iscale * iscale) / (2.0);
-  LineBufferType  lineBuf(lineLength);
+  LineBufferType  lineBuf(lineLength, 0.0);
   LabelBufferType labBuf(lineLength);
 
   inputIterator.SetDirection(direction);


### PR DESCRIPTION
Co-author: Jon Haitz Legarreta Gorroño <jon.haitz.legarreta@gmail.com>

This fix was confirmed with running valgrind.