### PR TITLE
COMP: Remove unused variable

### DIFF
--- a/include/itkLabelSetUtils.h
+++ b/include/itkLabelSetUtils.h
@@ -256,10 +256,9 @@ doOneDimensionErodeFirstPass(TInIter &          inputIterator,
   // restructure equation to reduce numerical error
   //  const RealType magnitude = (magnitudeSign * iscale * iscale)/(2.0 *
   // sigma);
-  const RealType                    magnitude = (magnitudeSign * iscale * iscale) / (2.0);
-  const typename TInIter::PixelType initPixelValue = 0.0;
-  LineBufferType                    lineBuf(lineLength, 0.0);
-  LabelBufferType                   labBuf(lineLength, 0.0);
+  const RealType  magnitude = (magnitudeSign * iscale * iscale) / (2.0);
+  LineBufferType  lineBuf(lineLength, 0.0);
+  LabelBufferType labBuf(lineLength, 0.0);
 
   inputIterator.SetDirection(direction);
   outputIterator.SetDirection(direction);


### PR DESCRIPTION
Remove unused variable.

Fixes:
```
Modules/Remote/LabelErodeDilate/include/itkLabelSetUtils.h:260:37:
 warning: unused variable 'initPixelValue' [-Wunused-variable]

  260 |   const typename TInIter::PixelType initPixelValue = 0.0;
      |                                     ^~~~~~~~~~~~~~
```

raised for example in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=10316578

Introducing the variable was an oversight in commit 108b0ba.